### PR TITLE
Support glob matching for `workspaces`

### DIFF
--- a/migrator.py
+++ b/migrator.py
@@ -1,5 +1,6 @@
 import binascii
 import click
+import fnmatch
 import hashlib
 import json
 import requests
@@ -297,6 +298,12 @@ def migrate(
             for tf_state in fetch_tfc("state-versions", state_filters)["data"]:
                 create_state(tf_state, workspace["data"]["id"])
 
+        def should_migrate_workspace(workspace_name):
+            for workspace in workspaces:
+                if fnmatch.fnmatch(workspace_name, workspace):
+                    return True
+            return False
+
         def migrate_variables():
             print("Migrating variables...")
 
@@ -364,7 +371,8 @@ def migrate(
 
             for tf_workspace in tfc_workspaces["data"]:
                 workspace_name = tf_workspace["attributes"]["name"]
-                if workspace_name not in workspaces and "*" not in workspaces:
+                if not should_migrate_workspace(workspace_name):
+                    print(f"Skipping workspace {workspace_name}...")
                     continue
 
                 workspace_exists = fetch_scalr(


### PR DESCRIPTION
Not sure why I assumed this would work, but it didn't, so I made it work :)

This allows to specify a list not just of workspace names or the literal `"*"` for `workspaces`, but also globs such as `"test-migrate-ws-*"`. Maybe handy for someone? 