### PR TITLE
fix: workspace creation and variable migration errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ override.tf.json
 venv
 generated-terraform/
 terraform-cloud/
+
+# Environment files with secrets
+.env
+.env.*

--- a/create_shared_variables.py
+++ b/create_shared_variables.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Script to create account-level variables in Scalr from TFC Variable Sets.
+This creates shared variables accessible by all workspaces.
+
+Usage:
+    python create_shared_variables.py --varset-name "Shared Secrets"
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from typing import Dict, List, Optional
+
+
+class APIClient:
+    """Base API client."""
+
+    def __init__(self, hostname: str, token: str, api_prefix: str):
+        self.hostname = hostname
+        self.token = token
+        self.api_prefix = api_prefix
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/vnd.api+json",
+        }
+
+    def request(
+        self, endpoint: str, method: str = "GET", data: Optional[Dict] = None
+    ) -> Dict:
+        """Make an API request."""
+        url = f"https://{self.hostname}{self.api_prefix}{endpoint}"
+        
+        body = None
+        if data:
+            body = json.dumps(data).encode("utf-8")
+
+        req = urllib.request.Request(url, data=body, method=method, headers=self.headers)
+
+        try:
+            with urllib.request.urlopen(req) as response:
+                if response.status == 204:
+                    return {}
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8")
+            try:
+                error_json = json.loads(error_body)
+                error_detail = error_json.get("errors", [{}])[0].get("detail", error_body)
+            except:
+                error_detail = error_body
+            return {"error": True, "code": e.code, "detail": error_detail}
+
+
+class TFCClient(APIClient):
+    """Terraform Cloud API client."""
+
+    def __init__(self, hostname: str, token: str):
+        url = f"https://{hostname}/.well-known/terraform.json"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req) as response:
+            well_known = json.loads(response.read().decode("utf-8"))
+            api_prefix = well_known.get("tfe.v2", "/api/v2/")
+        super().__init__(hostname, token, api_prefix)
+
+    def get_varsets(self, org_name: str) -> List[Dict]:
+        """Get all variable sets in an organization."""
+        return self.request(f"organizations/{org_name}/varsets").get("data", [])
+
+    def get_varset_vars(self, varset_id: str) -> List[Dict]:
+        """Get all variables in a variable set (handles pagination)."""
+        all_vars = []
+        page = 1
+        while True:
+            result = self.request(f"varsets/{varset_id}/relationships/vars?page[size]=100&page[number]={page}")
+            data = result.get("data", [])
+            all_vars.extend(data)
+            
+            # Check if there are more pages
+            meta = result.get("meta", {})
+            pagination = meta.get("pagination", {})
+            if page >= pagination.get("total-pages", 1):
+                break
+            page += 1
+        return all_vars
+
+
+class ScalrClient(APIClient):
+    """Scalr API client."""
+
+    def __init__(self, hostname: str, token: str):
+        super().__init__(hostname, token, "/api/iacp/v3/")
+        self.account_id = self._get_account_id()
+
+    def _get_account_id(self) -> str:
+        """Get the account ID for the current token."""
+        result = self.request("accounts")
+        accounts = result.get("data", [])
+        if not accounts:
+            raise Exception("No account found for token")
+        return accounts[0]["id"]
+
+    def get_account_vars(self) -> List[Dict]:
+        """Get account-level variables."""
+        return self.request(f"vars?filter[account]={self.account_id}&filter[workspace]=null&filter[environment]=null").get("data", [])
+
+    def create_account_variable(
+        self,
+        key: str,
+        value: str,
+        category: str,
+        sensitive: bool,
+        hcl: bool,
+        description: str,
+    ) -> Dict:
+        """Create an account-level variable in Scalr."""
+        data = {
+            "data": {
+                "type": "vars",
+                "attributes": {
+                    "key": key,
+                    "value": value,
+                    "category": category,
+                    "sensitive": sensitive,
+                    "hcl": hcl,
+                    "description": description or "",
+                },
+                "relationships": {
+                    "account": {
+                        "data": {"type": "accounts", "id": self.account_id}
+                    }
+                },
+            }
+        }
+        return self.request("vars", method="POST", data=data)
+
+
+def create_shared_variables(
+    tfc_client: TFCClient,
+    scalr_client: ScalrClient,
+    tfc_org: str,
+    varset_names: List[str],
+    dry_run: bool = False,
+) -> None:
+    """Create account-level variables in Scalr from TFC variable sets."""
+    
+    # Get existing Scalr account variables
+    print("Fetching existing Scalr account-level variables...")
+    existing_vars = scalr_client.get_account_vars()
+    existing_keys = {v["attributes"]["key"] for v in existing_vars}
+    print(f"Found {len(existing_keys)} existing account-level variables\n")
+
+    # Get TFC variable sets
+    print("Fetching TFC variable sets...")
+    all_varsets = tfc_client.get_varsets(tfc_org)
+    
+    all_vars = []
+    for vs in all_varsets:
+        vs_name = vs["attributes"]["name"]
+        if vs_name in varset_names:
+            print(f"  Loading '{vs_name}'...")
+            vs_vars = tfc_client.get_varset_vars(vs["id"])
+            print(f"    Found {len(vs_vars)} variables")
+            all_vars.extend(vs_vars)
+
+    print(f"\nTotal variables to create: {len(all_vars)}")
+    
+    if dry_run:
+        print("\n=== DRY RUN - No changes will be made ===\n")
+
+    created = 0
+    skipped = 0
+    errors = 0
+
+    for var in all_vars:
+        attrs = var["attributes"]
+        key = attrs["key"]
+        
+        if key in existing_keys:
+            print(f"  SKIP: {key} (already exists)")
+            skipped += 1
+            continue
+
+        # Convert TFC category to Scalr category
+        category = "shell" if attrs["category"] == "env" else attrs["category"]
+        
+        # For sensitive variables, use placeholder
+        if attrs["sensitive"]:
+            value = "PLACEHOLDER_FILL_ME_IN"
+        else:
+            value = attrs.get("value", "")
+
+        if dry_run:
+            print(f"  WOULD CREATE: {key} ({category}, sensitive={attrs['sensitive']})")
+            created += 1
+            continue
+
+        result = scalr_client.create_account_variable(
+            key=key,
+            value=value,
+            category=category,
+            sensitive=attrs["sensitive"],
+            hcl=attrs.get("hcl", False),
+            description=attrs.get("description", "") or f"Migrated from TFC variable set",
+        )
+
+        if result.get("error"):
+            print(f"  ERROR: {key} - {result.get('detail')}")
+            errors += 1
+        else:
+            existing_keys.add(key)
+            created += 1
+            sens_label = " (sensitive - needs value)" if attrs["sensitive"] else ""
+            print(f"  OK: {key}{sens_label}")
+
+    print(f"\n=== Summary ===")
+    print(f"Created: {created}")
+    print(f"Skipped (existing): {skipped}")
+    print(f"Errors: {errors}")
+    
+    if not dry_run and created > 0:
+        print(f"\nNext steps:")
+        print(f"1. Go to Scalr > Account Settings > Variables")
+        print(f"2. Find variables with value 'PLACEHOLDER_FILL_ME_IN'")
+        print(f"3. Update them with the correct values from your secrets manager")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create Scalr account-level variables from TFC variable sets")
+    parser.add_argument(
+        "--varset-names",
+        nargs="+",
+        default=["Shared Secrets"],
+        help="TFC variable set names to migrate",
+    )
+    parser.add_argument("--tfc-org", default="Huma", help="TFC organization name")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without creating variables")
+    args = parser.parse_args()
+
+    # Get credentials from environment
+    tfc_token = os.environ.get("TFC_TOKEN")
+    scalr_token = os.environ.get("SCALR_TOKEN")
+    scalr_hostname = os.environ.get("SCALR_HOSTNAME", "humaai.scalr.io")
+    tfc_hostname = os.environ.get("TFC_HOSTNAME", "app.terraform.io")
+
+    if not tfc_token or not scalr_token:
+        print("Error: TFC_TOKEN and SCALR_TOKEN environment variables required")
+        sys.exit(1)
+
+    tfc_client = TFCClient(tfc_hostname, tfc_token)
+    scalr_client = ScalrClient(scalr_hostname, scalr_token)
+
+    create_shared_variables(
+        tfc_client=tfc_client,
+        scalr_client=scalr_client,
+        tfc_org=args.tfc_org,
+        varset_names=args.varset_names,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/migrate_variables.py
+++ b/migrate_variables.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Script to migrate TFC workspace variables and variable sets to Scalr.
+
+Usage:
+    python migrate_variables.py --workspace-name dev --scalr-workspace-id ws-xxx
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from typing import Dict, List, Optional, Any
+
+
+class APIClient:
+    """Base API client for TFC and Scalr."""
+
+    def __init__(self, hostname: str, token: str, api_prefix: str):
+        self.hostname = hostname
+        self.token = token
+        self.api_prefix = api_prefix
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/vnd.api+json",
+        }
+
+    def request(
+        self, endpoint: str, method: str = "GET", data: Optional[Dict] = None
+    ) -> Dict:
+        """Make an API request."""
+        url = f"https://{self.hostname}{self.api_prefix}{endpoint}"
+        
+        body = None
+        if data:
+            body = json.dumps(data).encode("utf-8")
+
+        req = urllib.request.Request(url, data=body, method=method, headers=self.headers)
+
+        try:
+            with urllib.request.urlopen(req) as response:
+                if response.status == 204:
+                    return {}
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode("utf-8")
+            print(f"API Error {e.code}: {error_body}")
+            raise
+
+
+class TFCClient(APIClient):
+    """Terraform Cloud API client."""
+
+    def __init__(self, hostname: str, token: str):
+        # Get the API version from well-known endpoint
+        url = f"https://{hostname}/.well-known/terraform.json"
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(req) as response:
+            well_known = json.loads(response.read().decode("utf-8"))
+            api_prefix = well_known.get("tfe.v2", "/api/v2/")
+        super().__init__(hostname, token, api_prefix)
+
+    def get_workspace_vars(self, org_name: str, workspace_name: str) -> List[Dict]:
+        """Get variables for a workspace."""
+        endpoint = f"vars?filter[workspace][name]={workspace_name}&filter[organization][name]={org_name}"
+        return self.request(endpoint).get("data", [])
+
+    def get_varsets(self, org_name: str) -> List[Dict]:
+        """Get all variable sets in an organization."""
+        return self.request(f"organizations/{org_name}/varsets").get("data", [])
+
+    def get_varset_vars(self, varset_id: str) -> List[Dict]:
+        """Get variables in a variable set."""
+        return self.request(f"varsets/{varset_id}/relationships/vars").get("data", [])
+
+    def get_varset_workspaces(self, varset_id: str) -> List[Dict]:
+        """Get workspaces attached to a variable set."""
+        return self.request(f"varsets/{varset_id}/relationships/workspaces").get("data", [])
+
+
+class ScalrClient(APIClient):
+    """Scalr API client."""
+
+    def __init__(self, hostname: str, token: str):
+        super().__init__(hostname, token, "/api/iacp/v3/")
+
+    def get_workspace_vars(self, workspace_id: str) -> List[Dict]:
+        """Get variables for a workspace."""
+        return self.request(f"vars?filter[workspace]={workspace_id}").get("data", [])
+
+    def create_variable(
+        self,
+        key: str,
+        value: str,
+        category: str,
+        sensitive: bool,
+        hcl: bool,
+        description: str,
+        workspace_id: str,
+    ) -> Dict:
+        """Create a variable in Scalr."""
+        data = {
+            "data": {
+                "type": "vars",
+                "attributes": {
+                    "key": key,
+                    "value": value,
+                    "category": category,
+                    "sensitive": sensitive,
+                    "hcl": hcl,
+                    "description": description or "",
+                },
+                "relationships": {
+                    "workspace": {
+                        "data": {"type": "workspaces", "id": workspace_id}
+                    }
+                },
+            }
+        }
+        return self.request("vars", method="POST", data=data)
+
+
+def migrate_variables(
+    tfc_client: TFCClient,
+    scalr_client: ScalrClient,
+    tfc_org: str,
+    workspace_name: str,
+    scalr_workspace_id: str,
+    include_varsets: List[str],
+) -> None:
+    """Migrate variables from TFC to Scalr."""
+    
+    # Get existing Scalr variables to avoid duplicates
+    existing_vars = scalr_client.get_workspace_vars(scalr_workspace_id)
+    existing_keys = {v["attributes"]["key"] for v in existing_vars}
+    print(f"Found {len(existing_keys)} existing variables in Scalr workspace")
+
+    # Get workspace variables from TFC
+    print(f"\nFetching workspace variables from TFC...")
+    tfc_vars = tfc_client.get_workspace_vars(tfc_org, workspace_name)
+    print(f"Found {len(tfc_vars)} workspace variables in TFC")
+
+    # Get variable set variables if specified
+    varset_vars = []
+    if include_varsets:
+        print(f"\nFetching variable sets from TFC...")
+        all_varsets = tfc_client.get_varsets(tfc_org)
+        for vs in all_varsets:
+            vs_name = vs["attributes"]["name"]
+            if vs_name in include_varsets or vs["attributes"].get("global"):
+                print(f"  - Loading variables from '{vs_name}'...")
+                vs_vars = tfc_client.get_varset_vars(vs["id"])
+                varset_vars.extend(vs_vars)
+                print(f"    Found {len(vs_vars)} variables")
+
+    # Combine all variables
+    all_vars = tfc_vars + varset_vars
+    print(f"\nTotal variables to migrate: {len(all_vars)}")
+
+    # Migrate each variable
+    migrated = 0
+    skipped = 0
+    sensitive_skipped = []
+
+    for var in all_vars:
+        attrs = var["attributes"]
+        key = attrs["key"]
+        
+        if key in existing_keys:
+            print(f"  SKIP: {key} (already exists)")
+            skipped += 1
+            continue
+
+        # Convert TFC category to Scalr category
+        category = "shell" if attrs["category"] == "env" else attrs["category"]
+        
+        if attrs["sensitive"]:
+            # Can't get sensitive values from TFC API
+            sensitive_skipped.append(key)
+            print(f"  SKIP: {key} (sensitive - requires manual entry)")
+            continue
+
+        try:
+            scalr_client.create_variable(
+                key=key,
+                value=attrs.get("value", ""),
+                category=category,
+                sensitive=attrs["sensitive"],
+                hcl=attrs.get("hcl", False),
+                description=attrs.get("description", ""),
+                workspace_id=scalr_workspace_id,
+            )
+            existing_keys.add(key)
+            migrated += 1
+            print(f"  OK: {key}")
+        except Exception as e:
+            print(f"  ERROR: {key} - {e}")
+
+    print(f"\n=== Migration Summary ===")
+    print(f"Migrated: {migrated}")
+    print(f"Skipped (existing): {skipped}")
+    print(f"Skipped (sensitive): {len(sensitive_skipped)}")
+    
+    if sensitive_skipped:
+        print(f"\nSensitive variables requiring manual entry:")
+        for key in sensitive_skipped:
+            print(f"  - {key}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate TFC variables to Scalr")
+    parser.add_argument("--workspace-name", required=True, help="TFC workspace name")
+    parser.add_argument("--scalr-workspace-id", required=True, help="Scalr workspace ID")
+    parser.add_argument("--tfc-org", default="Huma", help="TFC organization name")
+    parser.add_argument(
+        "--include-varsets",
+        nargs="+",
+        default=["Dev Secrets", "Shared Secrets"],
+        help="Variable sets to include",
+    )
+    args = parser.parse_args()
+
+    # Get credentials from environment
+    tfc_token = os.environ.get("TFC_TOKEN")
+    scalr_token = os.environ.get("SCALR_TOKEN")
+    scalr_hostname = os.environ.get("SCALR_HOSTNAME", "humaai.scalr.io")
+    tfc_hostname = os.environ.get("TFC_HOSTNAME", "app.terraform.io")
+
+    if not tfc_token or not scalr_token:
+        print("Error: TFC_TOKEN and SCALR_TOKEN environment variables required")
+        sys.exit(1)
+
+    tfc_client = TFCClient(tfc_hostname, tfc_token)
+    scalr_client = ScalrClient(scalr_hostname, scalr_token)
+
+    migrate_variables(
+        tfc_client=tfc_client,
+        scalr_client=scalr_client,
+        tfc_org=args.tfc_org,
+        workspace_name=args.workspace_name,
+        scalr_workspace_id=args.scalr_workspace_id,
+        include_varsets=args.include_varsets,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Fixed workspace creation failing with 'none is not an allowed value' API error by filtering None values from attributes and relationships
- Fixed trigger-prefixes array containing null values when working directory is empty
- Fixed KeyError when processing sensitive variables from plan file
- Added .env files to gitignore to prevent accidental secret exposure
- Added debug logging for workspace creation payload (enable with SCALR_DEBUG_ENABLED=1)
- Added helper scripts for migrating TFC variable sets to Scalr account-level variables

## New Scripts
- `migrate_variables.py`: Migrates workspace-level variables from TFC to Scalr
- `create_shared_variables.py`: Creates account-level variables in Scalr from TFC variable sets (handles pagination)

## Test plan
- [x] Tested migration of workspaces with VCS configuration
- [x] Tested migration of workspaces with sensitive variables
- [x] Verified workspaces are created successfully in Scalr
- [x] Tested variable set migration with 199 variables