### PR TITLE
fix: stop run pagination when period boundary is reached in tfc-runs

### DIFF
--- a/tfc-runs/runs.py
+++ b/tfc-runs/runs.py
@@ -117,6 +117,7 @@ def list_all(hostname: str, period: int = None):
                     if check_period is None or created_at >= check_period:
                         org_total += 1
                     else:
+                        runs_token = None
                         break
 
             print(report % (name, org_total))


### PR DESCRIPTION
Fixes #23

When `break` was called on finding a run older than the period, it only exited the inner `for` loop — `runs_token` remained set, so the `while` loop continued fetching all remaining pages. Setting `runs_token = None` before `break` stops pagination immediately.