### PR TITLE
fix: handle empty response body in error handler in tfc-runs

### DIFF
--- a/tfc-runs/runs.py
+++ b/tfc-runs/runs.py
@@ -81,7 +81,10 @@ def list_all(hostname: str, period: int = None):
                     print("API rate limited, the maximum number of attempts exceeded")
                     sys.exit(1)
             else:
-                print(response.json()["errors"][0])
+                try:
+                    print(response.json()["errors"][0])
+                except Exception:
+                    print(f"Unexpected error: HTTP {status_code}")
                 sys.exit(1)
         return response.json()
 


### PR DESCRIPTION
Fixes #24

`response.json()["errors"][0]` raised an unhandled `JSONDecodeError` when the API returned a non-200 response with an empty body. Wrapped in a try/except to fall back to printing the HTTP status code.