### PR TITLE
fix: retry on 5xx server errors in tfc-runs

### DIFF
--- a/tfc-runs/runs.py
+++ b/tfc-runs/runs.py
@@ -80,6 +80,15 @@ def list_all(hostname: str, period: int = None):
                 else:
                     print("API rate limited, the maximum number of attempts exceeded")
                     sys.exit(1)
+            elif status_code >= 500:
+                if retry_attempt <= 10:
+                    retry_attempt += 1
+                    print(f"Server error {status_code}, retrying in 30 seconds, attempt #{retry_attempt}")
+                    time.sleep(30)
+                    return fetch_tfc(route, filters, retry_attempt)
+                else:
+                    print(f"Server error {status_code}, maximum retry attempts exceeded")
+                    sys.exit(1)
             else:
                 print(response.json()["errors"][0])
                 sys.exit(1)


### PR DESCRIPTION
Fixes #25

Added retry handling for `status_code >= 500`, consistent with the existing 429 rate-limit logic. Retries up to 10 times with a 30-second backoff before exiting.