### PR TITLE
fix: handle null TFC workspace attributes inherited from org defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `none is not an allowed value` (HTTP 422) error when creating a workspace whose `auto-apply`, `operations`, or `speculative-enabled` attribute is inherited from TFC organization defaults. The migrator now falls back to TFC's documented defaults (`auto-apply=false`, `operations=true`, `speculative-enabled=true`) when these fields are null.
+
 ## [0.3.6] - 2026-01-14
 
 ### Added

--- a/migrator.py
+++ b/migrator.py
@@ -1193,7 +1193,19 @@ class MigrationService:
         ConsoleOutput.info(f"Creating workspace '{attributes['name']}'...")
 
         terraform_version = self.enforce_max_version(attributes.get("terraform-version", "1.6.0"), 'Workspace')
-        execution_mode = "remote" if attributes.get("operations") else "local"
+        # TFC returns null for these fields when the workspace inherits the value from
+        # organization defaults rather than setting it explicitly. Scalr's API rejects
+        # null for these required booleans, so fall back to TFC's documented defaults.
+        auto_apply = attributes.get("auto-apply")
+        if auto_apply is None:
+            auto_apply = False
+        operations = attributes.get("operations")
+        if operations is None:
+            operations = True
+        speculative_enabled = attributes.get("speculative-enabled")
+        if speculative_enabled is None:
+            speculative_enabled = True
+        execution_mode = "remote" if operations else "local"
         global_remote_state = attributes.get("global-remote-state", False)
 
         platform = "opentofu" if (
@@ -1206,8 +1218,8 @@ class MigrationService:
 
         workspace_attrs = {
             "name": attributes["name"],
-            "auto-apply": attributes["auto-apply"],
-            "operations": attributes["operations"],
+            "auto-apply": auto_apply,
+            "operations": operations,
             "terraform-version": terraform_version,
             "working-directory": working_directory,
             "deletion-protection-enabled": not self.args.disable_deletion_protection,
@@ -1236,7 +1248,7 @@ class MigrationService:
 
             workspace_attrs["vcs-repo"] = {
                 "identifier": attributes["vcs-repo-identifier"],
-                "dry-runs-enabled": attributes.get("speculative-enabled", True),
+                "dry-runs-enabled": speculative_enabled,
                 "trigger-prefixes": trigger_prefixes,
                 "branch": branch,
                 "ingress-submodules": vcs_repo["ingress-submodules"],
@@ -1278,7 +1290,7 @@ class MigrationService:
         # Create Terraform resource
         resource_attributes = {
             "name": attributes["name"],
-            "auto_apply": attributes["auto-apply"],
+            "auto_apply": auto_apply,
             "execution_mode": execution_mode,
             "terraform_version": terraform_version,
             "working_directory": working_directory,
@@ -1293,7 +1305,7 @@ class MigrationService:
         if vcs_repo:
             resource_attributes["vcs_repo"] = {
                 "identifier": attributes["vcs-repo-identifier"],
-                "dry_runs_enabled": attributes["speculative-enabled"],
+                "dry_runs_enabled": speculative_enabled,
                 "branch": branch,
                 "ingress_submodules": vcs_repo["ingress-submodules"],
             }


### PR DESCRIPTION
TFC returns null for auto-apply, operations, and speculative-enabled when a workspace inherits those settings from organization defaults rather than setting them explicitly. The migrator forwarded those nulls to Scalr's API, which rejects them as "none is not an allowed value" (HTTP 422) and aborts workspace creation.

Fall back to TFC's documented defaults (auto-apply=false, operations=true, speculative-enabled=true) before sending the workspace payload. Also corrects execution_mode mapping when operations is null - TFC's default is remote, not local.