### PR TITLE
fix: explicitly import urllib.request in clients module

### DIFF
--- a/scalr_tfc_migrate/clients.py
+++ b/scalr_tfc_migrate/clients.py
@@ -3,6 +3,7 @@ import json
 import os
 import tarfile
 import urllib.error
+import urllib.request
 from typing import Dict, List, Optional
 from urllib.parse import urlencode
 


### PR DESCRIPTION
## Summary

- Add `import urllib.request` to `scalr_tfc_migrate/clients.py` so the module loads on environments where no transitive dependency happens to import that submodule first.

## Why

Customer reported the migrator failing with:

```
[ERROR] Migration failed: module 'urllib' has no attribute 'request'
```

The file imports `urllib.error` and `urllib.parse`, then uses `urllib.request.Request` and `urllib.request.urlopen` at lines 41 and 44. In Python 3, sibling `urllib.*` submodules are not implicitly loaded — `import urllib.error` does not make `urllib.request` available. The script worked on machines where some other import path happened to pull in `urllib.request` as a side effect, and broke on environments where nothing did.

## Test plan

- [x] `python3 -c "import urllib.error; import urllib.request"` resolves `urllib.request.Request` and `urllib.request.urlopen`
- [x] `scalr_tfc_migrate/clients.py` parses cleanly
- [ ] Reproduce the original failure on the customer's environment (or a clean venv) and confirm migration proceeds past module load

🤖 Generated with [Claude Code](https://claude.com/claude-code)